### PR TITLE
create translation to formal German

### DIFF
--- a/menus/german_formal.yaml
+++ b/menus/german_formal.yaml
@@ -1,0 +1,619 @@
+# actions.R
+
+"I just reset the script to its original state. If it doesn't refresh immediately, you may need to click on it.":
+ "Ich habe gerade das Script in den Originalzustand zurück gesetzt. Wenn es nicht sofort neu lädt, könnte es sein, dass Sie es noch mal anklicken müssen."
+
+"Sourcing your script...":
+ "Ihr Script wird neu geladen..."
+
+#"Entering play mode. Experiment as you please, then type nxt() when you are ready to resume the lesson.":
+# "Starte den Probiermodus. Experimentieren Sie frei nach belieben, dann tippen Sie nxt(), wenn Sie bereit sind die Lektion fortzusetzen."
+
+#"Returning to the main menu...":
+# "Kehre zurück ins Hauptmenü ..."
+
+"This feature is not implemented yet for Swirl.":
+ "Dieses Feature ist noch nicht in Swirl implementiert."
+
+# answerTests.R, answerTests2.R
+
+"That's not the expression I expected but it works.":
+ "Mit diesem Ausdruck habe ich nicht gerechnet, aber es scheint zu funktionieren."
+
+"The given range":
+ "Der gegebene Wertebereich"
+
+"is not numeric.":
+ "ist nicht numerisch."
+
+"I've executed the correct expression in case the result is needed in an upcoming question.":
+ "Ich habe den korrekten Ausdruck ausgeführt, falls das Ergebnis später noch einmal gebraucht wird."
+
+"does not exist.":
+ "existiert nicht."
+
+# args_specification.R
+
+## Do not translate 'test_course', 'test_lesson', or 'test'.
+"Must specify 'test_course' and 'test_lesson' to run in 'test' mode!":
+ "'test_course' und 'test_lesson' muss spezifiziert sein, um im 'test'-Modus zu laufen!"
+
+## Do not translate 'to' or 'from'.
+"Argument 'to' must be strictly greater than argument 'from'!":
+ "Das Argument 'to' muss strikt größer sein als das Argument 'from'!"
+
+# courseraCheck.R
+
+"Are you currently enrolled in the Coursera course associated with this lesson?":
+ "Sind Sie zur Zeit in einen Coursera-Kurs eingeschrieben, zu dem diese Lektion gehört?"
+
+"Would you like me to notify Coursera that you've completed this lesson?":
+ "Soll ich Coursera benachrichtigen, dass Sie diese Lektion abgeschlossen haben?"
+
+"If so, I'll need to get some more info from you.":
+ "Wenn ja, brauche ich noch ein paar Informationen von Ihnen."
+
+"Yes":
+ "Ja"
+
+"No":
+ "Nein"
+
+"Maybe later":
+ "Vielleicht später"
+
+"I'll try to tell Coursera you've completed this lesson now.":
+ "Ich werde nun versuchen Coursera mitzuteilen, dass Sie diese Lektion erfolgreich abgeschlossen haben."
+
+"You skipped too many questions! You'll need to complete":
+ "Sie haben zu viele Fragen übersprungen! Sie müssen diese Lektion"
+
+"this lesson again if you'd like to receive credit. Please":
+ "erneut durchgehen, wenn diese Lektion angerechnet werden soll."
+
+"don't skip more than one question next time.":
+ "Bitte überspringen Sie das nächste mal nicht mehr als eine Frage."
+
+"I've notified Coursera that you have completed ":
+ "Ich habe Coursera informiert, dass Sie die Lektion abgeschlossen haben."
+
+"I'm sorry, something went wrong with automatic submission.":
+ "Leider ist bei der automatischen Übertragung etwas schief gelaufen."
+
+"I'm sorry, something went wrong with establishing connection.":
+ "Leider konnte keine Verbindung aufgebaut werden."
+
+"To notify Coursera that you have completed this lesson,":
+ "Um Coursera zu informieren, dass Sie die Lektion abgeschlossen haben,"
+
+"please upload":
+ "reichen Sie bitte"
+
+"to Coursera manually. You may do so by visiting the Programming":
+ "manuell auf Coursera ein. Das können Sie machen, indem Sie die Programming"
+
+"Assignments page on your course website and selecting the Submit":
+ "Assignments Seite auf deiner Kurs-Seite aufrufen und den Submit-Button"
+
+"button next to the appropriate swirl lesson.":
+ "neben der entsprechenden Swirl-Lektion auswählen."
+
+"I've placed the file in the following directory:":
+ "Ich habe die Datei in das folgende Verzeichnis gelegt:"
+
+"Would you like to retry automatic submission or just submit manually?":
+ "Soll ich die automatische Übermittlung noch einmal versuchen oder wollen Sie lieber manuell einreichen?"
+
+"Retry automatic submission":
+ "Versuche Übermittlung erneut"
+
+"Submit manually":
+ "Übertrage manuell"
+
+"The first item I need is your Course ID. For example, if the":
+ "Die erste Angabe, die ich benötige ist Ihre Kurs-ID. Wenn die Seite"
+
+"homepage for your Coursera course was":
+ "für Ihren Coursera-Kurs z. B."
+
+"then your course ID would be 'rprog-001' (without the quotes).":
+ "war, dann wäre Ihre ID 'rprog-001' (ohne die Anführungszeichen)."
+
+"It looks like you entered a web address, which is not what I'm":
+ "Es sieht so aus, als hätten Sie eine Webadresse eingegeben, was nicht das ist,"
+
+"looking for.":
+ "was ich brauche."
+
+"It looks like you entered a numeric ID, which is not what I'm":
+ "Es sieht so aus, als hätten Sie eine numerische ID eingegeben, was nicht das ist,"
+
+"It looks like you entered the Course ID that I used as an":
+ "Es sieht so aus, als ob Sie die Kurs-ID eingegeben haben, die ich als"
+
+"example, which is not what I'm looking for.":
+ "Beispiel gegeben habe. Das ist nicht das, was ich brauche."
+
+"Instead, I need your Course ID, which is the last":
+ "Stattdessen brauche ich die Kurs-ID, die der letzte"
+
+"part of the web address for your Coursera course.":
+ "Teil der Webadresse Ihres Coursera-Kurses ist."
+
+"For example, if the homepage for your Coursera course was":
+ "Zum Beispiel, wenn die Homepage Ihres Coursera-Kurses"
+
+"'https://class.coursera.org/rprog-001',":
+ "'https://class.coursera.org/rprog-001',"
+
+#"then your course ID would be 'rprog-001' (without the quotes).":
+# "war, dann wäre Ihre Kurs-ID 'rprog-001' (ohne die Anführungszeichen)."
+
+"Submission login (email): ":
+ "Login für die Übertragung (Email): "
+
+"Submission password: ":
+ "Passwort für die Übertragung: "
+
+"Is the following information correct?":
+ "Sind die folgenden Informationen korrekt?"
+
+"Course ID: ":
+ "Kurs-ID: "
+
+"Yes, go ahead!":
+ "Ja, fahre fort!"
+
+"No, I need to change something.":
+ "Nein, ich muss etwas ändern."
+
+# install_courses.R
+
+"Course installed successfully!":
+ "Der Kurs wurde erfolgreich installiert!"
+
+"Course installation failed.":
+ "Die Installation ist fehlgeschlagen."
+
+"Argument 'course_name' must be surrounded by quotes (i.e. a character string)!":
+ "Das Argument 'course_name' muss mit Anführungszeichen eingerahmt werden (wie ein character string)!"
+
+"Argument 'dev' must be either TRUE or FALSE!":
+ "Das Argument 'dev' muss entweder TRUE oder FALSE sein!"
+
+"Please enter a valid name for a mirror. ('github' or 'bitbucket')":
+ "Bitte gebe einen gültigen Namen für den mirror ein. ('github' oder 'bitbucket')"
+
+"To access swirl courses in development on Bitbucket go to https://bitbucket.org/swirldevmirror/swirl_misc":
+ "Um auf Swirl-Kurse, die sich in der Entwicklung befinden, auf Bitbucket zugreifen zu können, gehen Sie auf https://bitbucket.org/swirldevmirror/swirl_misc"
+
+"Course '":
+ "Der Kurs '"
+
+"' not found in course repository! ":
+ "' konnte nicht im Kurs-Repository gefunden werden! "
+
+"Make sure you've got the name exactly right, then try again.":
+ "Stellen Sie sicher, dass Sie den Namen richtig geschrieben haben, dann probieren Sie es erneut."
+
+"Course uninstalled successfully!":
+ "Der Kurs wurde erfolgreich deinstalliert!"
+
+"Course not found!":
+ "Der Kurs konnte nicht gefunden werden!"
+
+"All courses uninstalled successfully!":
+ "Alle Kurse wurden erfolgreich deinstalliert!"
+
+"No courses found!":
+ "Keine Kurse gefunden!"
+
+"Argument 'multi' must be either TRUE or FALSE.":
+ "Das Argument 'multi' muss entweder TRUE oder FALSE sein."
+
+"Argument 'which_course' should only be specified when argument 'multi' is TRUE.":
+ "Das Argument 'which_course' sollte nur angegeben sein, wenn das Argument 'multi' auf TRUE gesetzt ist."
+
+"Course ":
+ "Der Kurs "
+
+" not in specified directory. Be careful, course names are case sensitive!":
+ " existiert nicht im Verzeichnis. Achten Sie auf die Groß- und Kleinschreibung der Kursnamen!"
+
+"Course directory is too large to install":
+ "Das Kursverzeichnis ist zu groß, um installiert werden zu können."
+
+"Please specify a value for either course_name or swc_path but not both.":
+ "Bitte geben Sie entweder für course_name oder für swc_path einen Wert an, aber nicht für beides."
+
+"It looks like your internet connection is not working.":
+ "Es sieht so aus, als würde Ihre Internetverbindung nicht funktionieren."
+
+"Go to http://swirlstats.com/scn/ and download the .swc file that corresponds to the course you wish to install.":
+ "Gehen auf http://swirlstats.com/scn/ und laden Sie die .swc Datei zu dem Kurs herunter, den Sie installieren möchten."
+
+"After downloading the .swc run install_course() and choose the file you downloaded.":
+ "Benutzen Sie install_course() und wählen Sie die .swc Datei aus, die Sie gerade herunter geladen haben."
+
+
+# instructionSet.R
+
+"ANSWER: ":
+ "ANTWORT: "
+
+"Yes or No? ":
+ "Ja oder Nein? "
+
+"yes":
+ "nein"
+
+"Type nxt() to continue":
+ "Tippen Sie nxt() um fortzufahren"
+
+"BUG: There are no tests for this question!":
+ "FEHLER: Es gibt keine Tests für diese Frage!"
+
+"Or, type info() for more options.":
+ "Oder tippen Sie info() für weitere Optionen."
+
+# utilities.R
+
+"Package":
+ "Paket"
+
+"loaded correctly!":
+ "korrekt geladen!"
+
+"This lesson requires the":
+ "Diese Lektion benötigt das"
+
+"package. Would you like me to install it for you now?":
+ "Paket. Soll ich es für Sie installieren?"
+
+"Attemping to load lesson dependencies...":
+ "Versuche Abhängigkeiten dieser Lektion zu laden ..."
+
+"Trying to install package":
+ "Versuche das Paket"
+
+"now...":
+ "zu installieren ..."
+
+"Could not install package":
+ "Konnte folgendes Paket nicht installieren:"
+ # is this been followed by a print of the package name?
+
+# menu.R
+
+"To begin, you must install a course. I can install a course for you from the internet, or I can send you to a web page (https://github.com/swirldev/swirl_courses) which will provide course options and directions for installing courses yourself. (If you are not connected to the internet, type 0 to exit.)":
+ "Um zu beginnen, müssen Sie einen Kurs installieren. Ich kann Ihnen einen Kurs aus dem Internet installieren, oder Sie auf eine Internetseite leiten (https://github.com/swirldev/swirl_courses), auf der einige Kurse zum download bereit stehen, inklusive Installationsanleitung. (Wenn Sie nicht mit dem Internet verbunden sind, tippen Sie 0 zum beenden.)"
+
+"Don't install anything for me. I'll do it myself.":
+ "Installiere nichts für mich, das werde ich selbst machen."
+
+"Sorry, but I'm unable to fetch ":
+ "Entschuldige, ich kann gerade "
+
+"right now. Are you sure you have an internet connection? If so, would you like to try again or visit the course repository for instructions on how to install a course manually? Type 0 to exit.":
+ "nicht herunterladen. Sind Sie sicher, dass Sie eine Verbindung zum Internet haben? Wenn ja, würden Sie es gerne erneut versuchen oder möchten Sie das Kurs-Repository besuchen, um eine Anleitung für die manuelle Installation zu erhalten? Tippen Sie 0 zum beenden."
+
+"Try again!":
+ "Probiere es erneut!"
+
+"Send me to the course repository for manual installation.":
+ "Leite mich auf das Kurs-Repository für eine manuelle Installation."
+
+"OK. I'm opening the swirl course respository in your browser.":
+ "OK, ich werde das Kurs-Repository in Ihrem Browser öffnen."
+
+"OK. I'm opening the swirl courses web page in your browser.":
+ "OK, ich werde die Webseite der Swirl-Kurse in Ihrem Browser öffnen."
+
+"Welcome to swirl! Please sign in. If you've been here before, use the same name as you did then. If you are new, call yourself something unique.":
+ "Willkommen zu Swirl! Bitte melden Sie sich an. Wenn Sie vorher schon hier waren, benutzen Sie den gleichen Namen wie zuvor. Wenn Sie neu sind, geben Sie sich einen eindeutigen Namen."
+
+"What shall I call you? ":
+ "Wie soll ich Sie nennen?  "
+
+"Thanks, ":
+ "Danke, "
+
+". Let's cover a couple of quick housekeeping items before we begin our first lesson. First of all, you should know that when you see '...', that means you should press Enter when you are done reading and ready to continue.":
+ ". Lassen Sie mich ein paar Grundlagen erklären, bevor wir mit der ersten Lektion beginnen. Zuallererst, immer wenn Sie '...' sehen, bedeutet das, dass Sie Enter drücken sollten, wenn Sie fertig mit lesen und bereit zum fortfahren sind."
+
+"...  <-- That's your cue to press Enter to continue":
+ "...  <-- Das ist Ihr Stichwort! Drücken Sie Enter um fortzufahren."
+
+"Also, when you see 'ANSWER:', the R prompt (>), or when you are asked to select from a list, that means it's your turn to enter a response, then press Enter to continue.":
+ "Wenn Sie 'ANTWORTE:' oder die R Eingabeaufforderung (>) sehen, oder wenn Sie aufgefordert werden, aus einer Liste auszuwählen, heißt das, dass es an Ihnen ist eine Antwort einzugeben. Wenn Sie fertig sind, drücken Sie Enter um fortzufahren."
+
+"Continue.":
+ "Fortsetzen."
+
+"Proceed.":
+ "Fortfahren."
+
+"Let's get going!":
+ "Lass uns loslegen!"
+
+"Select 1, 2, or 3 and press Enter":
+ "Wählen Sie 1, 2 oder 3 und drücken Sie Enter"
+
+"You can exit swirl and return to the R prompt (>) at any time by pressing the Esc key. If you are already at the prompt, type bye() to exit and save your progress. When you exit properly, you'll see a short message letting know you've done so.":
+ "Sie können jederzeit Swirl beenden und zur R Eingabeaufforderung (>) zurückkehren, indem Sie Esc drücken. Wenn Sie schon in der Eingabeaufforderung sind, tippen Sie bye() um Swirl zu beenden und Ihren Fortschritt zu speichern. Als Bestätigung bekommen Sie eine kurze Mitteilung angezeigt, dass Ihr Fortschritt gespeichert wurde."
+
+"Let's get started!":
+ "Lass uns anfangen!"
+
+"Would you like to continue with one of these lessons?":
+ "Möchten Sie eine dieser Lektionen fortsetzen?"
+
+"No. Let me start something new.":
+ "Nein, lass mich etwas neues starten."
+
+"Please choose a course, or type 0 to exit swirl.":
+ "Bitte wählen Sie einen Kurs oder tippen Sie 0 um Swirl zu beenden."
+
+"Take me to the swirl course repository!":
+ "Bring mich zum Swirl-Kurs-Repository!"
+
+"Please choose a lesson, or type 0 to return to course menu.":
+ "Bitte wählen Sie eine Lektion oder tippen Sie 0, um zum Kurs-Menü zurück zu kehren."
+
+# options.R
+
+"Please provide arguments so that appropriate options can be set.":
+ "Bitte geben Sie Argumente an, damit die entsprechenden Optionen gesetzt werden können."
+
+"Options set successfully!":
+ "Die Optionen wurden erfolgreich gesetzt!"
+
+"Option name '":
+ "Die Option namens '"
+
+"' not found.":
+ "' konnte nicht gefunden werden."
+
+"Option '":
+ "Option '"
+
+"' deleted successfully!":
+ "' wurde erfolgreich gelöscht!"
+
+# Phrases.R
+
+"You got it!" :
+ "Alles klar!"
+
+"Nice work!":
+ "Gute Arbeit!"
+
+"Keep up the great work!":
+ "Gute Arbeit! Immer weiter so!"
+
+"You are doing so well!":
+ "Das machen Sie sehr gut!"
+
+"You nailed it! Good job!":
+ "Genau richtig! Gute Arbeit!"
+
+"You're the best!":
+ "Sie sind Spitze!"
+
+"You are amazing!":
+ "Sie sind großartig!"
+
+"Great job!":
+ "Gut gemacht!"
+
+"You are quite good my friend!":
+ "Du machen Sie das sehr gut!"
+
+"You got it right!":
+ "Das war genau richtig!"
+
+"That's correct!":
+ "Das ist korrekt!"
+
+"You are really on a roll!":
+ "Da sind Sie genau auf dem richtigen Weg!"
+
+"Excellent job!":
+ "Exzellente Arbeit!"
+
+"That's a job well done!":
+ "So ist es genau richtig!"
+
+"Almost! Try again.":
+ "Fast! Versuchen Sie es einfach noch mal."
+
+"You almost had it, but not quite. Try again.":
+ "Sie hatten es fast, aber nicht ganz. Probieren Sie es einfach noch mal."
+
+"Give it another try.":
+ "Probieren Sie es noch mal."
+
+"Not quite! Try again.":
+ "Nicht ganz. Versuchen Sie es noch mal."
+
+"Not exactly. Give it another go.":
+ "Nicht direkt. Probieren Sie es noch mal."
+
+"That's not exactly what I'm looking for. Try again.":
+ "Das ist nicht ganz das, was ich haben wollte. Versuchen Sie es noch mal."
+
+"Nice try, but that's not exactly what I was hoping for. Try again.":
+ "Guter Versuch, aber das ist nicht ganz das, wonach ich gesucht habe. Versuchen Sie es noch mal."
+
+"Keep trying!":
+ "Nicht aufgeben! Probieren Sie es noch mal!"
+
+"That's not the answer I was looking for, but try again.":
+ "Das ist nicht die Antwort, die ich erhofft hatte, aber versuchen Sie es einfach noch mal."
+
+"Not quite right, but keep trying.":
+ "Nicht ganz richtig. Bleiben Sie dran!"
+
+"You're close...I can feel it! Try it again.":
+ "Sie haben es fast, das hab ich im Gefühl! Versuchen Sie es noch mal."
+
+"Correct!":
+ "Richtig!"
+
+"Incorrect. Please try again.":
+ "Falsch. Bitte versuchen Sie es noch einmal."
+
+# post.R
+
+#"Lesson complete! Exiting swirl now...":
+# "Lektion abgeschlossen! Swirl wird nun beendet ..."
+
+# progress.R
+
+"Please enter a valid username.":
+ "Bitte geben Sie einen gültigen Benutzernamen ein."
+
+"Deleted progress for user: ":
+ "Lösche den Fortschritt für Benutzer: "
+
+"Could not find account for user: ":
+ "Konnte keinen Eintrag finden für den Benutzer: "
+
+# swirl.R
+
+"Leaving swirl now. Type swirl() to resume.":
+ "Swirl wird jetzt beendet. Tippen Sie swirl(), um es wieder zu starten."
+
+"When you are at the R prompt (>):":
+ "Wenn Sie in der Eingabeaufforderung von R sind (>):"
+
+"-- Typing skip() allows you to skip the current question.":
+ "-- Wenn Sie skip() eintippen, können Sie die aktuelle Frage überspringen."
+
+"-- Typing play() lets you experiment with R on your own; swirl will ignore what you do...":
+ "-- Wenn Sie play() eintippen, können Sie frei in R experimentieren. Swirl wird ignorieren was Sie dort tun ..."
+
+"-- UNTIL you type nxt() which will regain swirl's attention.":
+ "-- ... bis Sie nxt() eintippen, was Sie wieder zurück zu Swirl bringt."
+
+"-- Typing bye() causes swirl to exit. Your progress will be saved.":
+ "-- Wenn Sie bye() eintippen, wird Swirl beendet. Ihr Fortschritt wird gespeichert."
+
+"-- Typing main() returns you to swirl's main menu.":
+ "-- Wenn Sie main() eintippen, kommen Sie zurück ins Hauptmenü von Swirl."
+
+"-- Typing info() displays these options again.":
+ "-- Wenn Sie info() eintippen, werden diese Optionen wieder angezeigt."
+
+"Resuming lesson...":
+ "Setze die Lektion fort ..."
+
+"Entering play mode. Experiment as you please, then type nxt() when you are ready to resume the lesson.":
+ "Beginne den Probiermodus. Experimentieren Sie wie es Ihnen gefällt, dann tippen Sie nxt(), wenn Sie bereit sind, um die Lektion fortzusetzen."
+
+"Entering the following correct answer for you...":
+ "Ich gebe die folgende korrekte Antwort für Sie ein ..."
+
+"Returning to the main menu...":
+ "Gehe zum Hauptmenü ..."
+
+"Lesson complete! Exiting swirl now...":
+ "Lektion erfolgreich abgeschlossen! Beende Swirl jetzt ..."
+
+"You've reached the end of this lesson! Returning to the main menu...":
+ "Sie haben das Ende der Lektion erreicht! Kehren Sie zurück zum Hauptmenü ..."
+
+"I just sourced the following script, which demonstrates one possible solution.":
+ "Ich habe gerade das folgende Skript geladen und ausgeführt, was Ihnen eine mögliche Lösung zeigen soll."
+
+"Press Enter when you are ready to continue...":
+ "Drücken Sie Enter wenn Sie bereit zum fortfahren sind ..."
+
+# zzz.R
+
+"Hi! I see that you have some variables saved in your":
+ "Guten Tag! Ich sehe, dass Sie einige Variablen gespeichert haben in Ihrem"
+
+"workspace. To keep things running smoothly, I recommend you clean up":
+ "workspace. Damit alles reibungslos läuft, empfehle ich etwas aufzuräumen,"
+
+"before starting swirl.":
+ "bevor Sie Swirl starten."
+
+"Type ls() to see a list of the variables in your workspace.":
+ "Tippen Sie ls(), um eine Liste der Variablen in Ihrem workspace anzuzeigen."
+
+"Then, type rm(list=ls()) to clear your workspace.":
+ "Dann tippen Sie rm(list=ls()), um Ihren workspace zu leeren."
+
+"Type swirl() when you are ready to begin.":
+ "Tippen Sie swirl(), wenn Sie bereit zum Beginnen sind."
+
+"Hi! Type swirl() when you are ready to begin.":
+ "Guten Tag! Tippen Sie swirl(), wenn Sie bereit zum Beginnen sind."
+
+ # New for swirl 2.4
+
+"Could not connect to course file.":
+ "Konnte nicht zu Kurs-Datei verbinden."
+
+"Are you sure you want to uninstall all swirl courses?":
+ "Sind Sie sicher, dass Sie alle Swirl-Kurse deinstallieren möchten?"
+
+"This will delete all of the contents of your swirl course directory.":
+ "Dies wird den gesamten Inhalt Ihres Swirl-Verzeichnisses löschen."
+
+"right now. Are you sure you have an internet connection?":
+ "gerade jetzt. Sind Sie sicher, dass Sie eine Verbindung zum Internet haben?"
+
+"If so, would you like to try again or visit":
+ "Wenn ja, würden Sie es gerne noch mal versuchen oder möchten Sie"
+
+"the course repository for instructions on how to":
+ "das Kurs-Repository besuchen, für weitere Instruktionen, wie man"
+
+"install a course manually? Type 0 to exit.":
+ "einen Kurs manuell installieren kann? Tippen Sie 0, um zu beenden."
+
+"Please don't use any quotes or other punctuation in your name.":
+ "Bitte benutzen Sie keine Anführungzeichen oder andere Satzzeichen in Ihrem Namen."
+
+"\n...  <-- That's your cue to press Enter to continue":
+ "\n...  <-- Das ist das Zeichen, dass Sie Enter drücken sollten um fortzufahren"
+
+"\nSelect 1, 2, or 3 and press Enter":
+ "\nWählen Sie 1, 2 oder 3 und drücken Sie Enter"
+
+"You can exit swirl and return to the R prompt (>) at any time by pressing the Esc key. If you are already at the prompt, type bye() to exit and save your progress. When you exit properly, you'll see a short message letting you know you've done so.":
+ "Sie können jederzeit Swirl beenden und zur R Eingabeaufforderung (>) zurückkehren, indem Sie die Esc-Taste drücken. Wenn Sie schon in der Eingabeaufforderung sind, tippen Sie bye(), um Swirl zu beenden und Ihren Fortschritt zu speichern. Wenn Sie Swirl auf die richtige Weise beenden, bekommen Sie eine kurze Bestätigungsmeldung."
+
+"All that hard work is paying off!":
+ "All die harte Arbeit zahlt sich nun aus!"
+
+"Keep working like that and you'll get there!":
+ "Machen Sie weiter so und Sie werden Großes erreichen!"
+
+"Perseverance, that's the answer.":
+ "Hartnäckig bleiben, das ist die Antwort!"
+
+"Your dedication is inspiring!":
+ "Ihre Hingabe ist beeindruckend!"
+
+"All that practice is paying off!":
+ "Das viele Üben zahlt sich aus!"
+
+"Excellent work!":
+ "Exzellente Arbeit!"
+
+"That's the answer I was looking for.":
+ "Das ist die Antwort, die ich haben wollte."
+
+"One more time. You can do it!":
+ "Ein Versuch noch. Sie schaffen das!"
+
+"Not quite, but you're learning! Try again.":
+ "Nicht ganz, aber Sie lernen dazu! Probieren Sie es noch mal."
+
+"Try again. Getting it right on the first try is boring anyway!":
+ "Probieren Sie es noch mal. Es beim ersten Mal richtig zu machen, ist sowieso langweilig!"
+ 


### PR DESCRIPTION
in German there are two ways of approaching someone. The existing
translation german.yaml uses the informal way ("du"). This adds the
formal way of approaching the user treating it as if it was a new
language: german_formal. Course authors can choose which one to use by
setting the preferred language option.
